### PR TITLE
Tweak the folder display name

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,9 @@ export function activate( context: vscode.ExtensionContext ) {
 		}
 
 		const fullPath = 'ponyssh:/' + host + ( remotePath.startsWith( '/' ) ? '' : '/' ) + remotePath;
+		const name = host + ':' + ( remotePath.startsWith( '/' ) ? '' : '/' ) + remotePath;
 		const newFolder = {
-			name: fullPath,
+			name,
 			uri: vscode.Uri.parse( fullPath ),
 		};
 


### PR DESCRIPTION
This PR seeks to address two problems:

- Having `ponyssh` in the display name takes up a lot of space, in an area with an extremely limited number of columns.
- Having the host name as part of the path makes it difficult to tell which is the host, and which is the path.

Before:

<img width="338" alt="" src="https://user-images.githubusercontent.com/352291/54893940-68534400-4f0c-11e9-9221-58a2629fa7e1.png">

After:

<img width="338" alt="" src="https://user-images.githubusercontent.com/352291/54893948-72754280-4f0c-11e9-832c-5ed7c281d4ce.png">
