### PR TITLE
Add a server default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ For example:
  "ponyssh.hosts": { 
         "example": {
             "host": "example.com",
-            "username": "mylogin"
+            "username": "mylogin",
+            "path": "/srv/www"
         },
         "something-else": {
             "host": "another-host.example.com",
@@ -42,6 +43,7 @@ The following host configuration options are accepted:
 - `username` - Username for authentication
 - `password` - Password for authentication
 - `agent` - Specify agent or UNIX socket to use. Generally `"pageant"` on Windows, or `$SSH_AUTH_SOCK` on POSIX systems.
+- `path` - The default path to use when opening a folder on this host.
 
 If you don't specify a `password` or `agent` in your host configuration, Pony SSH will automatically try to use a sensible platform-specific default. (eg: `pageant` or `$SSH_AUTH_SOCK`).
 

--- a/src/Host.ts
+++ b/src/Host.ts
@@ -8,6 +8,7 @@ export interface HostConfig {
     host: string;
     username: string;
     agent?: string;
+    path?: string;
 }
 
 export class Host {

--- a/src/PonyFileSystem.ts
+++ b/src/PonyFileSystem.ts
@@ -112,6 +112,7 @@ export class PonyFileSystem implements vscode.FileSystemProvider {
                 "host": configHost.host,
                 "username": configHost.username,
                 "agent": configHost.agent || ( configHost.password ? undefined : defaultAgent ),
+                "path": configHost.path,
             };
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,12 +19,14 @@ export function activate( context: vscode.ExtensionContext ) {
 			return;
 		}
 
+		const defaultPath = availableHosts[ host ].path || '~';
+
 		// Ask user to enter remote path
 		let remotePath = await vscode.window.showInputBox( {
-			placeHolder: 'Remote path. Default: ~/',
+			placeHolder: 'Remote path. Default: ' + defaultPath,
 		} );
 		if ( '' === remotePath ) {
-			remotePath = '~';
+			remotePath = defaultPath;
 		}
 		if ( ! remotePath ) {
 			return;


### PR DESCRIPTION
This PR allows a `path` config option to be set on a server, to use as the default path when opening a new folder on that server.

<img width="597" alt="" src="https://user-images.githubusercontent.com/352291/54894633-c2a1d400-4f0f-11e9-805e-1a4789d9fab5.png">
