### PR TITLE
Allow host config to specify a shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each host can be configured with the following options:
 - `privateKeyFile` - Specify a file containing your private key for authentication. eg: `~/.ssh/id_rsa`.
 - `passphrase` - Enter a passphrase for decrypting your private key. If left blank, Pony SSH will prompt you for a passphrase if needed.
 - `python` - Specify the full path to your python installation on your remote host. *Default: Your system default python installation*
+- `shell` - Specify a shell to use when executing remote commands, including command line arguments used to pass in a command to execute. eg: `sh -c` or `sudo sh -c`. *Default: `sh -c`*
 
 ### About SSH Agents
 
@@ -87,6 +88,19 @@ Load a private key from a file:
     }
   }
 ```
+
+Connect to a host and use `sudo`:
+```
+ "ponyssh.hosts": {
+    "example-sudo": {
+       "host": "example.com",
+       "username": "my-login",
+       "agent": true,
+       "shell": "sudo sh -c"
+    }
+  }
+```
+(Note: This setup assumes your user is allowed to sudo without a password)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each host can be configured with the following options:
 - `privateKeyFile` - Specify a file containing your private key for authentication. eg: `~/.ssh/id_rsa`.
 - `passphrase` - Enter a passphrase for decrypting your private key. If left blank, Pony SSH will prompt you for a passphrase if needed.
 - `python` - Specify the full path to your python installation on your remote host. *Default: Your system default python installation*
-- `shell` - Specify a shell to use when executing remote commands, including command line arguments used to pass in a command to execute. eg: `sh -c` or `sudo sh -c`. *Default: `sh -c`*
+- `shell` - Specify a shell to use when executing remote commands. Include any command line arguments needed to pass your shell a command to execute. Each command to execute will get appended to your shell string. eg: `sh -c` or `sudo sh -c`. *Default: `sh -c`*
 
 ### About SSH Agents
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 								},
 								"shell": {
 									"type": "string",
-									"description": "Override the shell to use when executing commands. Command will be passed to the shell as the last argument as a string",
+									"description": "Shell to use when executing remote commands. Include any command line arguments needed to pass your shell a command to execute. Each command to execute will get appended to your shell string. eg: `sh -c` or `sudo sh -c`",
 									"default": "sh -c"
 								}
 							}

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
 								"python": {
 									"type": "string",
 									"description": "Path to python 2.7 or 3.x to use for remote worker script. Leave out for default python"
+								},
+								"shell": {
+									"type": "string",
+									"description": "Override the shell to use when executing commands. Command will be passed to the shell as the last argument as a string",
+									"default": "sh -c"
 								}
 							}
 						}

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -346,7 +346,6 @@ export class Connection extends EventEmitter {
 
     private wrapShellCommand( args: string[] ): string {
         const escapedArgs = shellEscape( args );
-        log.debug( this.config );
 
         if ( this.config.shell ) {
             return this.config.shell + ' ' + escapedArgs;

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -291,7 +291,7 @@ export class Connection extends EventEmitter {
     private async verifyWorkerScript(): Promise<boolean> {
         return new Promise( ( resolve, reject ) => {
             log.debug( 'Verifying worker script' );
-            const command = shellEscape( [ 'sh', '-c', pilotCommand ] );
+            const command = this.wrapShellCommand( [ pilotCommand ] );
             this.client.exec( command, ( err, channel ) => {
                 if ( err ) {
                     return reject( err );
@@ -344,10 +344,21 @@ export class Connection extends EventEmitter {
         }
     }
 
+    private wrapShellCommand( args: string[] ): string {
+        const escapedArgs = shellEscape( args );
+        log.debug( this.config );
+
+        if ( this.config.shell ) {
+            return this.config.shell + ' ' + escapedArgs;
+        } else {
+            return 'sh -c ' + escapedArgs;
+        }
+    }
+
     private async uploadWorkerScript() {
         return new Promise( ( resolve, reject ) => {
             const pythonCommand = shellEscape( [ this.pythonCommand(), '-c', uploadCommand ] );
-            const shellCommand = shellEscape( [ 'sh', '-c', pythonCommand ] );
+            const shellCommand = this.wrapShellCommand( [ pythonCommand ] );
 
             log.debug( 'Opening upload channel for worker script' );
             this.client.exec( shellCommand, async ( err, channel ) => {
@@ -386,7 +397,7 @@ export class Connection extends EventEmitter {
     private async startWorkerChannel( args: string[] = [] ): Promise<Channel> {
         return new Promise<Channel>( ( resolve, reject ) => {
             const pythonCommand = shellEscape( [ this.pythonCommand() ] ) + ' ~/.pony-ssh/worker.zip ' + shellEscape( args );
-            const shellCommand = shellEscape( [ 'sh', '-c', pythonCommand ] );
+            const shellCommand = this.wrapShellCommand( [ pythonCommand ] );
 
             this.client.exec( shellCommand, async ( err, channel ) => {
                 if ( err ) {

--- a/src/Host.ts
+++ b/src/Host.ts
@@ -17,6 +17,7 @@ export interface HostConfig {
     privateKeyFile?: string;
     passphrase?: string;
     python?: string;
+    shell?: string;
 }
 
 type ChangeCallback = ( host: string, path: string, type: vscode.FileChangeType ) => void;


### PR DESCRIPTION
Allow host config to specify a shell command to use when executing remote commands. Useful for setting up custom environments, using specific shells, or calling `sudo`.

Example config: 
```
 "ponyssh.hosts": {
    "example-sudo": {
       "host": "example.com",
       "username": "my-login",
       "agent": true,
       "shell": "sudo sh -c"
    }
  }
```