### PR TITLE
Improvements to error reporting during initial connection

### DIFF
--- a/src/PonyWorker.ts
+++ b/src/PonyWorker.ts
@@ -359,8 +359,12 @@ export class PonyWorker extends EventEmitter {
         this.emit( 'error', this, err );
     }
 
-    private onChannelStderr( data: string ) {
-        log.warn( 'Channel STDERR output: ', data );
+    private onChannelStderr( data: Buffer ) {
+        const stringData = data.toString();
+
+        if ( stringData.trim().length > 0 ) {
+            log.warn( 'Channel STDERR output: ', stringData );
+        }
     }
 
     private onChannelEnd() {


### PR DESCRIPTION
Includes two fixes / improvements:

1. Ensures that STDERR output is displayed as a string, rather than a truncated array of ASCII hex values, and
2. Makes sure that errors that occur during the primary worker thread startup get caught and reported in the UI, rather than waiting for everything to time out. 