### PR TITLE
Make pilot command check config.python rather than “python” if given

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -13,10 +13,10 @@ import expandHomeDir = require( 'expand-home-dir' );
 import { log, LoggingLevel } from "./Log";
 const shellEscape = require( 'shell-escape' );
 
-const pilotCommand = '' +
+const pilotCommand = ( pythonCommand: string ) => '' +
     'F=~/.pony-ssh/worker.zip;' +
     'M="ponyssh-mar""ker";' +
-    'if command -v python >/dev/null;then ' +
+    `if command -v ${pythonCommand} >/dev/null;then ` +
         'if [ -e $F ];then ' +
             'if [ $( which md5 ) ];then ' +
                 'H=`cat $F|md5`;' +
@@ -292,7 +292,7 @@ export class Connection extends EventEmitter {
     private async verifyWorkerScript(): Promise<boolean> {
         return new Promise( ( resolve, reject ) => {
             log.debug( 'Verifying worker script' );
-            const command = this.wrapShellCommand( [ pilotCommand ] );
+            const command = this.wrapShellCommand( [ pilotCommand( this.pythonCommand() ) ] );
             this.client.exec( command, ( err, channel ) => {
                 if ( err ) {
                     return reject( err );


### PR DESCRIPTION
There might not be a `python` on the PATH, even when a compatible version of Python is installed. This is the case on OpenBSD, where none of the Python packages create a `python` symlink by default.

[POSIX says](https://pubs.opengroup.org/onlinepubs/009695399/utilities/command.html#tag_04_24_04) `command -v` accepts arguments with slashes, and merely converts them to absolute paths.