### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -35,8 +35,8 @@ const uploadCommand = '' +
     'import os,sys;' +
     'd=os.path.expanduser("~/.pony-ssh");' +
     'os.path.exists(d) or os.mkdir(d);' +
-    'f=open(d+"/worker.zip","w");' +
-    'f.write(sys.stdin.read())';
+    'f=open(d+"/worker.zip","wb");' +
+    'f.write(sys.stdin.buffer.read() if sys.version_info >= (3, 0) else sys.stdin.read())';
 
 export interface ServerInfo {
     home: string;

--- a/src/worker/handlers.py
+++ b/src/worker/handlers.py
@@ -1,4 +1,5 @@
 from collections import deque
+import binascii
 import hashlib
 import logging
 import os
@@ -84,7 +85,7 @@ def handle_get_server_info(args):
 
     if cacheKey == None or len(cacheKey) < 64:
         cacheKeyIsNew = True
-        cacheKey = os.urandom(32).encode('hex')
+        cacheKey = binascii.hexlify(os.urandom(32))
         with open(cacheKeyFile, 'wb') as keyFileHandle:
             keyFileHandle.write(cacheKey)
 


### PR DESCRIPTION
Fixes references to `sys.stdin` in the worker uploader script, fixes reference to `bytes.encode` when reading from `urandom`.